### PR TITLE
Update cloneVM.ps1

### DIFF
--- a/cloneVM.ps1
+++ b/cloneVM.ps1
@@ -146,6 +146,10 @@ if(!$dstResourceGroup){
     }
     Else{
         Write-Host "Using existing resource group $destinationResourceGroup"
+        # ISSUE 
+        # Need to capture the location of the named (passed by parameter) destination resource group if it already exists
+        # Otherwise, create the new storage account will fail
+        $resourceGroupLocation = $dstResourceGroup.Location
         }
 
 


### PR DESCRIPTION
If the existing destination resource group exists, then its location needs to be captured into the variable for use when creating the new storage account